### PR TITLE
chore(docs): use correct intigriti naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go bot that publishes (non-sensitive) new intigriti findings to Slack.
 3. Retrieve your [intigriti API token](https://intigriti.com/) and pass your (external) IP address for whitelisting.
 4. Create your configuration file:
 ```yaml
-# skip findings in audit, archived and closed
+# skip findings in triage, archived and closed
 include_non_ready: false
 
 # how often to check in minutes


### PR DESCRIPTION
The correct naming at intigriti for the status where the triagers are doing there job is 'Triage'
See: https://kb.intigriti.com/en/articles/3379382-submission-lifecycle